### PR TITLE
Refactored service initialization and moved to a separate fixture

### DIFF
--- a/WebFormsTest.Test/Fritz.WebFormsTest.Test.csproj
+++ b/WebFormsTest.Test/Fritz.WebFormsTest.Test.csproj
@@ -114,6 +114,7 @@
     <Compile Include="SetPageStateFixture.cs" />
     <Compile Include="WebApplicationProxyFixture.cs" />
     <Compile Include="WebConfigFixture.cs" />
+    <Compile Include="WebServiceFixture.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config">

--- a/WebFormsTest.Test/WebApplicationProxyFixture.cs
+++ b/WebFormsTest.Test/WebApplicationProxyFixture.cs
@@ -50,34 +50,6 @@ namespace Fritz.WebFormsTest.Test
     }
 
     [Fact]
-	public void CheckContextIsInjectedIntoWebService()
-	{
-	    var service = new TestWebService();
-
-		WebApplicationProxy.InjectContextIntoWebService(service);
-
-		Assert.Equal(HttpContext.Current, service.Context);
-	}
-
-    [Fact]
-    public void CheckSessionExistsOnInjectedContextWithSessionOnWebService()
-    {
-        var service = new TestWebService();
-
-        var session = WebApplicationProxy.GetNewSession(new Dictionary<string, object>
-        {
-            ["TestCode"] = "123"
-        });
-
-        WebApplicationProxy.InjectContextIntoWebService(service, context =>
-        {
-            context.AddSession(session);
-        });
-
-        Assert.Equal("123", service.Session["TestCode"]);
-    }
-
-    [Fact]
     public void BeginProcessing()
     {
 

--- a/WebFormsTest.Test/WebApplicationProxyFixture.cs
+++ b/WebFormsTest.Test/WebApplicationProxyFixture.cs
@@ -181,6 +181,28 @@ namespace Fritz.WebFormsTest.Test
 
     }
 
+    [Fact]
+    public void FriendlyUrlIsHandled()
+    {
+
+      // Arrange
+      var expectedType = typeof(WebFormsTest.Web.Scenarios.Postback.Textbox_StaticId);
+
+      // Act
+
+      // Get the default page
+      var locatedType = WebApplicationProxy.GetPageByLocation("/Scenarios/Postback/Textbox_StaticId").GetType();
+      _testHelper.WriteLine("Type returned: " + locatedType.BaseType.FullName);
+
+      // NOTE: This needs to look at the BaseType of the type returned from the GetPageByLocation
+      // because this is the JIT'd page which is merged with the ASPX and inherits from the type
+      // defined in the code-behind
+
+      // Assert
+      Assert.Equal(expectedType.FullName, locatedType.BaseType.FullName);
+
+    }
+
   }
 
 }

--- a/WebFormsTest.Test/WebConfigFixture.cs
+++ b/WebFormsTest.Test/WebConfigFixture.cs
@@ -25,7 +25,7 @@ namespace Fritz.WebFormsTest.Test
 
     public ITestOutputHelper Output { get; }
 
-    //[Fact]
+    [Fact(Skip ="Config inspection is unreliable in integration tests")]
     public void CanFetchAppSettings()
     {
 
@@ -43,7 +43,7 @@ namespace Fritz.WebFormsTest.Test
 
     }
 
-    //[Fact]
+    [Fact(Skip = "Config inspection is unreliable in integration tests")]
     public void CanFetchConnectionStrings()
     {
 

--- a/WebFormsTest.Test/WebServiceFixture.cs
+++ b/WebFormsTest.Test/WebServiceFixture.cs
@@ -1,0 +1,48 @@
+﻿using Fritz.WebFormsTest.Web.Scenarios.WebServices;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web;
+using Xunit;
+
+namespace Fritz.WebFormsTest.Test
+{
+
+  /// <summary>
+  /// Verift that web services are able to be constructed properly
+  /// </summary>
+  [Collection("Precompiler collection")]
+  public class WebServiceFixture
+  {
+    
+    [Fact]
+    public void CheckContextIsInjectedIntoWebService()
+    {
+
+      var service = WebApplicationProxy.GetService<TestWebService>();
+
+      Assert.Equal(HttpContext.Current, service.Context);
+    }
+
+    [Fact]
+    public void CheckSessionExistsOnInjectedContextWithSessionOnWebService()
+    {
+
+      var session = WebApplicationProxy.GetNewSession(new Dictionary<string, object>
+      {
+        ["TestCode"] = "123"
+      });
+
+      var service = WebApplicationProxy.GetService<TestWebService>(context =>
+      {
+        context.AddSession(session);
+      });
+
+      Assert.Equal("123", service.Session["TestCode"]);
+    }
+
+
+  }
+}

--- a/WebFormsTest/WebApplicationProxy.cs
+++ b/WebFormsTest/WebApplicationProxy.cs
@@ -230,6 +230,8 @@ namespace Fritz.WebFormsTest
 
       if (_Instance == null || !_Instance.Initialized) throw new InvalidOperationException("The WebApplicationProxy has not been created and initialized properly");
 
+      location = HandleFriendlyUrls(location);
+
       var returnType = _Instance._compiler.GetCompiledType(location);
       SubstituteDummyHttpContext(location);
 
@@ -559,6 +561,38 @@ namespace Fritz.WebFormsTest
 
       AppDomain.CurrentDomain.SetData("APP_CONFIG_FILE", Path.Combine(WebRootFolder, "web.config"));
       //      WebConfigurationManager.OpenWebConfiguration(Path.Combine(WebRootFolder, "web.con‌​fig"));
+
+    }
+
+    private static string HandleFriendlyUrls(string location)
+    {
+
+      var legitExtensions = new[] { ".aspx", ".master", ".ascx", ".ashx", ".asmx" };
+
+      // Return immediately if this already has an ASPX in it
+      if (legitExtensions.Any(e => location.ToLowerInvariant().Contains(e)) )
+        return location;
+
+      var folders = location.Split('/');
+      var currentLocation = "";
+      var mpProvider = new TestConfigMapPath();
+      foreach (var folder in folders)
+      {
+
+        if (string.IsNullOrEmpty(folder)) continue;
+
+        currentLocation += "/" + folder;
+        var absoluteLocation = mpProvider.MapPath("", currentLocation);
+        if (Directory.Exists(absoluteLocation)) continue;
+        if (File.Exists(absoluteLocation + ".aspx")) {
+          break;
+        }
+
+        throw new FileNotFoundException("Unable to locate the file requested", location);
+
+      }
+
+      return currentLocation + ".aspx";
 
     }
 


### PR DESCRIPTION
Refactored service initialization from #48 to allow the WebApplicationProxy to create the Service and provide any context or constructor arguments.

Moved Service tests to a WebServiceFixture for easier management as additional Service features are added
- @developerDoug - Please review to ensure this meets your needs
